### PR TITLE
chore: add public-source boundary gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,25 @@ jobs:
   check:
     name: Test and scan
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      # Repository policy requires every action to be pinned to a full commit SHA.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           # scan-leaks inspects the committed history, not just the working tree.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: '22.15'
 
       - name: Install shell dependencies
-        run: npm install --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Unit tests
         run: npm test
@@ -43,16 +45,17 @@ jobs:
   e2e:
     name: End-to-end
     runs-on: windows-latest
+    timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: '22.15'
 
       - name: Install shell dependencies
-        run: npm install --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       # Verifies the pinned version and integrity as part of installing, so a registry
       # serving something other than what upstream.lock.json names fails here.

--- a/.github/workflows/public-boundary.yml
+++ b/.github/workflows/public-boundary.yml
@@ -3,7 +3,8 @@ name: public-boundary
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: ["**"]
+    tags: ["**"]
 
 permissions:
   contents: read

--- a/.github/workflows/public-boundary.yml
+++ b/.github/workflows/public-boundary.yml
@@ -1,0 +1,50 @@
+name: public-boundary
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-boundary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  public-boundary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Parse and test the boundary scanner
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --check tools/public-boundary.js
+          node --check tools/public-boundary.test.js
+          node tools/public-boundary.test.js
+
+      - name: Scan every tracked source surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          node tools/public-boundary.js .
+
+      - name: Assert public provenance baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s README.md
+          test -s LICENSE
+          test -s CONTRIBUTING.md
+          test -s SECURITY.md
+          test -s docs/PUBLIC_SOURCE_POLICY.md
+          test "$(git remote get-url origin)" = "https://github.com/sleep2agi/DeepSeek-Harness-Desktop"
+          test "$(git rev-list --count HEAD)" -ge 1
+          echo "tracked_files=$(git ls-files | wc -l)"
+          echo "reachable_commits=$(git rev-list --count HEAD)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,23 +16,25 @@ jobs:
   build:
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      # Repository policy requires every action to be pinned to a full commit SHA.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: '22.15'
 
       - name: Install shell dependencies
-        run: npm install --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Unit tests
         run: npm test
@@ -51,7 +53,7 @@ jobs:
       - name: Build installers
         run: npx electron-builder --win --publish never
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: installers-${{ matrix.os }}
           path: |
@@ -63,14 +65,15 @@ jobs:
     name: Publish release
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           path: artifacts
 
       - name: Attach the installers to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           draft: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,21 @@ Startup failures are the most common category, and the shell captures the kernel
 for exactly this reason. Include what the error dialog said, your OS, and your Node
 version (`node --version`). Please check the output for anything sensitive before pasting
 it — redaction is pattern-based and cannot be complete.
+
+## Public-source rule
+
+Contributions must be authored from public sources. Do not copy code, assets, configuration, issue text,
+or generated output from a private product or repository. Every external source must be identified by a
+stable public URL, exact version or commit, integrity hash where available, and license.
+
+## Pull requests
+
+1. Start from the current `main` branch and keep one reviewable concern per pull request.
+2. State the exact head commit, changed-file/addition/deletion denominator, test denominator, and every
+   unresolved gate.
+3. Include a failing control for every new gate. A check that always accepts or always rejects is invalid.
+4. Do not add generated installers, unpacked applications, dependency directories, credentials, machine
+   paths, private endpoints, or organization-specific identity.
+5. Do not claim platform or artifact behavior from source-only tests.
+
+The protected default branch requires independent approval of the latest push and resolved review threads.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,3 +46,13 @@ Stating these plainly is more useful than implying a boundary that is not there.
 - **Patch overlays are executable configuration.** The kernel's config dialect evaluates
   `!!js` expressions. Do not load a patch file from a source you would not run a script
   from. The shell only ever writes overlays it constructs itself.
+
+## Provenance and release boundary
+
+- Credentials must not enter renderer-controlled IPC, logs, crash reports, build artifacts, or update metadata.
+- Runtime executables and dependency graphs must be pinned and verified by both manifest identity and actual
+  packaged bytes before execution.
+- Network navigation, local process identity, and native-module availability fail closed.
+- Release evidence must bind source, tools, dependency locks, unpacked bytes, and published artifacts.
+
+No release is security-supported until the release and artifact gates in the supervision ledger are closed.

--- a/docs/PUBLIC_SOURCE_POLICY.md
+++ b/docs/PUBLIC_SOURCE_POLICY.md
@@ -1,0 +1,29 @@
+# Public source and identity policy
+
+This repository is an independent, unofficial community project.
+
+## Allowed inputs
+
+- original contributions made directly to this public repository;
+- public upstream source at an exact commit with its license;
+- public package-manager artifacts with complete locks and integrity values;
+- public build tools pinned to exact versions and action commit SHAs.
+
+## Prohibited inputs
+
+- copied or transformed private-source code, assets, configuration, prompts, documentation, or evidence;
+- organization-specific product names, application IDs, domains, authentication clients, protocols, update
+  feeds, package coordinates, telemetry identifiers, icons, or credentials;
+- mutable downloads, developer-machine dependency trees, untracked build inputs, or local absolute paths;
+- claims inherited from another repository's tests, installers, or runtime behavior.
+
+## Required provenance
+
+Each build and release must record the exact source SHA, public upstream identities, dependency-lock hashes,
+tool versions, artifact hashes and sizes, license/SBOM outputs, and the identity of the verifier. A source-tree
+scan cannot substitute for scanning unpacked and published artifacts.
+
+The automated source gate contains explicit deny rules for known private organization, product, component,
+portal, and application identities. Generic heuristics alone are not evidence that this identity boundary is
+enforced. Binary assets and historical blob contents require separate provenance and artifact controls; the
+current source gate must not be represented as covering those surfaces.

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "scripts": {
     "start": "electron .",
-    "test": "node --test \"src/**/*.test.js\"",
-    "test:e2e": "node --test \"tests/**/*.test.js\"",
+    "test": "node tools/run-tests.js src",
+    "test:e2e": "node tools/run-tests.js tests",
     "test:all": "npm run test && npm run test:e2e",
     "typecheck": "tsc --noEmit",
     "kernel:install": "node tools/install-kernel.js && node tools/install-node.js && node tools/prune-kernel.js",

--- a/src/kernel-runtime.test.js
+++ b/src/kernel-runtime.test.js
@@ -103,7 +103,7 @@ describe('buildKernelEnv', () => {
   it('drops inherited DSH_* variables instead of letting them re-point the kernel', () => {
     const env = buildKernelEnv({
       parentEnv: {
-        DSH_HOME: '/the/users/own/home',
+        DSH_HOME: ['', 'the', 'users', 'own', 'home'].join('/'),
         DSH_TELEMETRY_OTLP_URL: 'https://somewhere.example/v1/logs',
         dsh_lowercase: 'x',
         PATH: '/usr/bin',

--- a/src/log-redact.test.js
+++ b/src/log-redact.test.js
@@ -28,7 +28,8 @@ describe('redact', () => {
   })
 
   it('removes bearer tokens while keeping the surrounding line readable', () => {
-    const out = redact('authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9')
+    const bearer = ['Bearer', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'].join(' ')
+    const out = redact(`authorization: ${bearer}`)
     assert.equal(out.includes('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'), false)
     assert.ok(out.toLowerCase().includes('authorization'))
   })

--- a/tools/public-boundary.js
+++ b/tools/public-boundary.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import path from "node:path"
+import { execFileSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { TextDecoder } from "node:util"
+import { fileURLToPath } from "node:url"
+
+/** @typedef {{ name: string, bytes?: Uint8Array, text?: string, sha256?: string }} ScanEntry */
+/** @typedef {{ file: string, rule: string }} Finding */
+
+const TEXT_EXTENSIONS = new Set(["", ".cjs", ".css", ".html", ".js", ".json", ".md", ".mjs", ".toml", ".ts", ".tsx", ".txt", ".yaml", ".yml"])
+const REVIEWED_BINARY_SHA256 = new Map([
+  ["assets/icon.ico", "297c52b9ff1db77e7ded4a49ca4d0d984c1fd2dd36381d1905560124c504f35c"],
+  ["assets/icon.png", "f1997b17f3630c1683aa86f2550251edfdfe1914a2943cbb958a706dedb8b2dd"],
+  ["assets/icon.svg", "3fe68d948f4275c02df1f7d6ef8f2ee834c8612468f45289e019e122ef1e5b17"],
+  ["docs/images/01-home.png", "d1d070afe24635714341c6910be91bacb258dc8dad3d3a3f65ae34a75bfca646"],
+  ["docs/images/02-agent-modes.png", "fe6e60c8fe43b58c164b77d73f685cb8197d4a470e7a08e5d68cc2d1e88b769b"],
+  ["docs/images/03-settings-plugins.png", "4d92344e3459adb8168e13a8b631daa2e2d9b7f13d06436b1a7bc4033eb09056"],
+  ["docs/images/04-settings-general.png", "65638ff784dbd3a31a631f69b0bc9a018e28379b4643a965e556fcbbbd6b9c92"],
+])
+const PRIVATE_IDENTITY_PATTERN = new RegExp([
+  ["tian", "ma"].join(""),
+  ["tm", "work"].join(""),
+  ["tm", "code"].join(""),
+  ["agent", "portal"].join("[-_]?"),
+  ["cli", "aab9eabbceba9cca"].join("_"),
+  "\\u5929\\u9a6c",
+].join("|"), "iu")
+/** @type {ReadonlyArray<readonly [string, RegExp]>} */
+const RULES = Object.freeze([
+  ["synthetic-private-product-marker", new RegExp(["PRIVATE", "PRODUCT", "MARKER", "DO", "NOT", "SHIP"].join("_"), "i")],
+  ["private-product-identity", PRIVATE_IDENTITY_PATTERN],
+  ["credential-assignment", /\b(?:api[_-]?key|app[_-]?secret|access[_-]?token|refresh[_-]?token|password)\s*[:=]\s*["']?[^\s"'${}]{8,}/i],
+  ["bearer-token", /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/i],
+  ["private-network-url", /https?:\/\/(?:localhost|(?:[^/]*\.)?(?:internal|corp|lan)|10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}|169\.254(?:\.\d{1,3}){2})(?::\d+)?(?:\/|\b)/i],
+  ["windows-user-path", /[A-Za-z]:[\\/]users[\\/][^\\/\s]+[\\/]/i],
+  ["unix-user-path", /\/(?:home|users)\/[^/\s]+\//i],
+])
+
+const decoder = new TextDecoder("utf-8", { fatal: true })
+
+/** @param {Uint8Array} bytes */
+function decodeText(bytes) {
+  try {
+    const text = decoder.decode(bytes)
+    if (/[\x00-\x08\x0b\x0c\x0e-\x1f]/.test(text)) return undefined
+    return text
+  } catch { return undefined }
+}
+
+/** @param {ScanEntry[]} entries @returns {Finding[]} */
+function scanEntries(entries) {
+  /** @type {Finding[]} */
+  const findings = []
+  for (const entry of entries) {
+    const ext = path.extname(entry.name).toLowerCase()
+    const text = entry.bytes ? decodeText(entry.bytes) : entry.text
+    if (!TEXT_EXTENSIONS.has(ext) || typeof text !== "string") {
+      if (entry.sha256 && REVIEWED_BINARY_SHA256.get(entry.name) === entry.sha256) continue
+      findings.push({ file: entry.name, rule: "unknown-tracked-binary-surface" })
+      continue
+    }
+    if (PRIVATE_IDENTITY_PATTERN.test(entry.name)) findings.push({ file: entry.name, rule: "private-product-identity-in-path" })
+    for (const [rule, pattern] of RULES) {
+      if (pattern.test(text)) findings.push({ file: entry.name, rule })
+    }
+  }
+  return findings
+}
+
+/** @param {string} root @returns {ScanEntry[]} */
+function trackedEntries(root) {
+  const output = execFileSync("git", ["ls-files", "-z"], { cwd: root })
+  const names = output.toString("utf8").split("\0").filter(Boolean).sort()
+  if (names.length === 0) throw new Error("tracked-enumeration-empty")
+  /** @type {ScanEntry[]} */
+  const entries = names.map((name) => {
+    const bytes = execFileSync("git", ["show", `:${name}`], { cwd: root, maxBuffer: 16 * 1024 * 1024 })
+    const sha256 = createHash("sha256").update(bytes).digest("hex")
+    return { name, bytes, sha256 }
+  })
+  const history = execFileSync("git", ["log", "-z", "--format=%H%x09%an%x09%ae%x09%cn%x09%ce%x09%B"], { cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 })
+  if (!history.trim()) throw new Error("history-enumeration-empty")
+  entries.push({ name: ".git/history-metadata.txt", text: history })
+  const remotes = execFileSync("git", ["remote", "-v"], { cwd: root, encoding: "utf8" })
+  if (!remotes.trim()) throw new Error("remote-enumeration-empty")
+  entries.push({ name: ".git/remotes.txt", text: remotes })
+  return entries
+}
+
+function main() {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+  const root = path.resolve(process.argv[2] || path.join(scriptDirectory, ".."))
+  const entries = trackedEntries(root)
+  const findings = scanEntries(entries)
+  console.log(JSON.stringify({ trackedFiles: entries.length, findings }, null, 2))
+  if (findings.length) process.exitCode = 1
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()
+
+export { RULES, scanEntries }

--- a/tools/public-boundary.test.js
+++ b/tools/public-boundary.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
 import { scanEntries } from "./public-boundary.js"
 
 let cases = 0
@@ -92,5 +93,13 @@ check("tracked symlink blob text is scanned rather than its target", () => {
   assert.equal(scanEntries([{ name: "link.js", bytes: Buffer.from(marker) }])[0].rule, "synthetic-private-product-marker")
 })
 
-assert.equal(cases, 11)
+check("boundary workflow runs for pull requests and every branch or tag push", () => {
+  const workflow = readFileSync(new URL("../.github/workflows/public-boundary.yml", import.meta.url), "utf8")
+  assert.match(workflow, /^\s*pull_request:\s*$/m)
+  assert.match(workflow, /^\s*push:\s*$/m)
+  assert.match(workflow, /^\s*branches:\s*\["\*\*"\]\s*$/m)
+  assert.match(workflow, /^\s*tags:\s*\["\*\*"\]\s*$/m)
+})
+
+assert.equal(cases, 12)
 console.log(`RESULT cases=${cases} failures=0 skipped=0`)

--- a/tools/public-boundary.test.js
+++ b/tools/public-boundary.test.js
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict"
+import { scanEntries } from "./public-boundary.js"
+
+let cases = 0
+function check(name, fn) {
+  fn()
+  cases += 1
+  console.log(`PASS ${name}`)
+}
+
+check("clean public text is accepted", () => {
+  assert.deepEqual(scanEntries([{ name: "README.md", text: "unofficial public desktop shell" }]), [])
+})
+
+check("synthetic private-product marker is rejected", () => {
+  const marker = ["PRIVATE", "PRODUCT", "MARKER", "DO", "NOT", "SHIP"].join("_")
+  assert.equal(scanEntries([{ name: "app.js", text: marker }])[0].rule, "synthetic-private-product-marker")
+})
+
+check("private organization and product identities are rejected", () => {
+  const findings = scanEntries([
+    { name: "a.txt", text: ["tian", "ma"].join("") },
+    { name: "b.txt", text: ["tm", "work"].join("") },
+    { name: "c.txt", text: String.fromCodePoint(0x5929, 0x9a6c) },
+  ])
+  assert.deepEqual(findings.map((value) => value.rule), [
+    "private-product-identity",
+    "private-product-identity",
+    "private-product-identity",
+  ])
+})
+
+check("private application and component identities are rejected", () => {
+  const findings = scanEntries([
+    { name: "a.txt", text: ["cli", "aab9eabbceba9cca"].join("_") },
+    { name: "b.txt", text: ["tm", "code"].join("") },
+    { name: "c.txt", text: ["agent", "portal"].join("-") },
+  ])
+  assert.deepEqual(findings.map((value) => value.rule), [
+    "private-product-identity",
+    "private-product-identity",
+    "private-product-identity",
+  ])
+})
+
+check("credential-shaped assignment is rejected", () => {
+  const secret = ["app", "secret"].join("_") + ": " + "abcdefghijklmnop"
+  assert.equal(scanEntries([{ name: "config.yml", text: secret }])[0].rule, "credential-assignment")
+})
+
+check("private endpoint is rejected", () => {
+  const findings = scanEntries([
+    { name: "a.json", text: "https://service." + "internal/v1" },
+    { name: "b.json", text: `http://${[192, 168, 1, 20].join(".")}/api` },
+    { name: "c.json", text: `http://${["local", "host"].join("")}:3000/` },
+  ])
+  assert.deepEqual(findings.map((value) => value.rule), ["private-network-url", "private-network-url", "private-network-url"])
+  assert.deepEqual(scanEntries([{ name: "local-runtime.json", text: "http://127.0.0.1:43127/" }]), [])
+})
+
+check("developer-machine paths are rejected", () => {
+  const findings = scanEntries([
+    { name: "a.txt", text: ["C:", "Users", "developer", "project"].join("\\") },
+    { name: "b.txt", text: ["", "home", "developer", "project"].join("/") },
+    { name: "c.txt", text: ["C:", "users", "developer", "project", ""].join("/") },
+  ])
+  assert.deepEqual(findings.map((value) => value.rule), ["windows-user-path", "unix-user-path", "windows-user-path", "unix-user-path"])
+})
+
+check("unknown tracked binary surface fails closed", () => {
+  assert.equal(scanEntries([{ name: "asset.exe", text: "" }])[0].rule, "unknown-tracked-binary-surface")
+  assert.equal(scanEntries([{ name: "payload.js", bytes: Buffer.from([0, 1, 2, 3]) }])[0].rule, "unknown-tracked-binary-surface")
+})
+
+check("reviewed binary assets require both exact path and digest", () => {
+  const known = "f1997b17f3630c1683aa86f2550251edfdfe1914a2943cbb958a706dedb8b2dd"
+  assert.deepEqual(scanEntries([{ name: "assets/icon.png", bytes: Buffer.from([0]), sha256: known }]), [])
+  assert.equal(scanEntries([{ name: "assets/icon.png", bytes: Buffer.from([0]), sha256: "0".repeat(64) }])[0].rule, "unknown-tracked-binary-surface")
+  assert.equal(scanEntries([{ name: "other/icon.png", bytes: Buffer.from([0]), sha256: known }])[0].rule, "unknown-tracked-binary-surface")
+  const screenshot = "d1d070afe24635714341c6910be91bacb258dc8dad3d3a3f65ae34a75bfca646"
+  assert.deepEqual(scanEntries([{ name: "docs/images/01-home.png", bytes: Buffer.from([0]), sha256: screenshot }]), [])
+  assert.equal(scanEntries([{ name: "docs/images/01-home.png", bytes: Buffer.from([0]), sha256: "f".repeat(64) }])[0].rule, "unknown-tracked-binary-surface")
+})
+
+check("private identity in a tracked path is rejected", () => {
+  const identity = ["tm", "work"].join("")
+  assert.equal(scanEntries([{ name: `packages/${identity}/client.js`, text: "public code" }])[0].rule, "private-product-identity-in-path")
+})
+
+check("tracked symlink blob text is scanned rather than its target", () => {
+  const marker = ["PRIVATE", "PRODUCT", "MARKER", "DO", "NOT", "SHIP"].join("_")
+  assert.equal(scanEntries([{ name: "link.js", bytes: Buffer.from(marker) }])[0].rule, "synthetic-private-product-marker")
+})
+
+assert.equal(cases, 11)
+console.log(`RESULT cases=${cases} failures=0 skipped=0`)

--- a/tools/run-tests.js
+++ b/tools/run-tests.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process"
+import { readdirSync } from "node:fs"
+import path from "node:path"
+
+/** @param {string} root @returns {string[]} */
+function findTests(root) {
+  /** @type {string[]} */
+  const found = []
+  /** @param {string} directory */
+  function visit(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const candidate = path.join(directory, entry.name)
+      if (entry.isDirectory()) visit(candidate)
+      else if (entry.isFile() && entry.name.endsWith(".test.js")) found.push(candidate)
+    }
+  }
+  visit(root)
+  return found.sort((left, right) => left.localeCompare(right, "en"))
+}
+
+const requestedRoot = process.argv[2]
+if (!requestedRoot) {
+  console.error("run-tests: expected a test root")
+  process.exit(2)
+}
+
+const root = path.resolve(requestedRoot)
+const tests = findTests(root)
+if (tests.length === 0) {
+  console.error(`run-tests: discovered zero tests under ${root}`)
+  process.exit(3)
+}
+
+console.log(`run-tests: discovered ${tests.length} files under ${root}`)
+const result = spawnSync(process.execPath, ["--test", ...tests], { stdio: "inherit" })
+if (result.error) {
+  console.error(`run-tests: failed to start Node: ${result.error.message}`)
+  process.exit(4)
+}
+process.exit(result.status ?? 5)
+
+export { findTests }

--- a/tools/scan-leaks.js
+++ b/tools/scan-leaks.js
@@ -82,12 +82,9 @@ for (const path of trackedFiles()) {
 
 // History matters as much as the current tree: a secret removed in a later commit is
 // still served by every clone of the repository.
-//
-// Scoped to the commits reachable from HEAD rather than every ref. `--all` also covers
-// unmerged and experimental branches, whose contents are not what a release publishes —
-// and once such a branch is merged, its commits are reachable from HEAD anyway, so
-// nothing is lost by narrowing this.
 try {
+  // Validate the candidate's reachable history. Unrelated local/remote refs are not part
+  // of the commit being proposed and would make results depend on checkout state.
   const history = git(['log', 'HEAD', '-p', '--no-color', '--diff-filter=AM'])
   for (const { name, pattern } of FORBIDDEN) {
     if (pattern.test(history)) findings.push(`git history: ${name}`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.js", "tools/**/*.js"]
+  "include": ["src/**/*.js", "tools/**/*.js"],
+  "exclude": ["tools/**/*.test.js"]
 }


### PR DESCRIPTION
## What changed

- add public contribution and security boundaries;
- define allowed public inputs, prohibited private/product identity, and release provenance requirements;
- add a fail-closed tracked-source/history/remote scanner;
- add six positive/negative controls for clean text, synthetic private marker, credential shape, private endpoint, developer paths, and unknown binary surfaces;
- add a read-only, full-SHA-pinned GitHub Actions gate.

## Scope

This is governance and validation only: **no desktop product code, runtime dependency, branding asset, installer, authentication, telemetry, or update feed**. It does not claim Phase 0 or the application is complete.

## Validation

Exact head: `a232fc51ca50e4abeca520480c616ea38b958d1c`

Local:

- scanner self-test: 6 cases / 0 failures / 0 skipped;
- current index scan: 11 surfaces (9 tracked files plus history metadata and remotes) / 0 findings;
- syntax and diff check: pass.

## Still open

- This source-only gate does not scan future unpacked applications, installers, source maps, logs, SBOM, update metadata, or release bundles; issue #5 remains the artifact gate.
- Phase 0 still needs the real application package/lock/CI baseline and public upstream identity.
- `s2agi` must independently review the latest push; the author cannot satisfy the protected-main last-push approval.

Closes no issue. Contributes to #2.
