### PR TITLE
fix: close critical runtime lifecycle gaps

### DIFF
--- a/src/main-wiring.test.js
+++ b/src/main-wiring.test.js
@@ -1,0 +1,27 @@
+import { strict as assert } from 'node:assert'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+
+const source = await readFile(new URL('./main.js', import.meta.url), 'utf8')
+
+describe('main security wiring', () => {
+  it('installs default-deny permissions on the production window session', () => {
+    assert.match(source, /installDefaultDenyPermissions\(webContents\.session\)/)
+  })
+
+  it('assigns the window before rechecking the exact startup process', () => {
+    const assigned = source.indexOf('mainWindow = window')
+    const checked = source.indexOf('assertStartupRuntimeCurrent(kernel)')
+    assert.ok(assigned >= 0 && checked > assigned)
+  })
+
+  it('routes before-quit through the async coordinator', () => {
+    assert.match(source, /app\.on\('before-quit', createBeforeQuitHandler\(\{/)
+    assert.doesNotMatch(source, /app\.on\('before-quit',[\s\S]*void shutdown\(\)/)
+  })
+
+  it('uses the identity-preserving production shutdown helper', () => {
+    assert.match(source, /const shutdown = createRuntimeShutdown\(\{/)
+    assert.match(source, /clearIfCurrent: \(expected\) => \{ if \(kernel === expected\) kernel = null \}/)
+  })
+})

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,10 @@ import { KernelProcess, findFreePort } from './kernel-process.js'
 import { buildKernelArgs, buildKernelEnv, isSupportedNodeVersion } from './kernel-runtime.js'
 import { httpProbe, waitForReady } from './readiness.js'
 import { buildShellPatch, serialisePatch } from './shell-patch.js'
+import { installDefaultDenyPermissions } from './permission-policy.js'
+import { createBeforeQuitHandler } from './quit-coordinator.js'
+import { assertStartupRuntimeCurrent } from './startup-current.js'
+import { createRuntimeShutdown } from './runtime-shutdown.js'
 import { writeFile } from 'node:fs/promises'
 import {
   SECURE_WEB_PREFERENCES,
@@ -159,6 +163,15 @@ function createWindow(origin) {
   // into it there is no shell-provided surface for it to reach through.
 
   const { webContents } = window
+  mainWindow = window
+  try {
+    assertStartupRuntimeCurrent(kernel)
+  } catch (error) {
+    mainWindow = null
+    window.destroy()
+    throw error
+  }
+  installDefaultDenyPermissions(webContents.session)
 
   webContents.on('will-navigate', (event, url) => {
     if (!isAllowedNavigation(url, origin)) {
@@ -201,12 +214,10 @@ function tail(text, lines) {
   return text.split('\n').slice(-lines).join('\n')
 }
 
-/** @returns {Promise<void>} */
-async function shutdown() {
-  const running = kernel
-  kernel = null
-  if (running !== null) await running.stop()
-}
+const shutdown = createRuntimeShutdown({
+  getCurrent: () => kernel,
+  clearIfCurrent: (expected) => { if (kernel === expected) kernel = null },
+})
 
 // A second instance would start a second kernel against the same home directory, and the
 // two would overwrite each other's state.
@@ -222,7 +233,7 @@ if (!app.requestSingleInstanceLock()) {
   app.whenReady().then(async () => {
     try {
       const { origin } = await startKernel()
-      mainWindow = createWindow(origin)
+      createWindow(origin)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
 
@@ -244,14 +255,13 @@ if (!app.requestSingleInstanceLock()) {
     }
   })
 
-  app.on('window-all-closed', async () => {
-    await shutdown()
-    app.quit()
-  })
+  app.on('window-all-closed', () => app.quit())
 
   // `before-quit` is the last point at which the kernel can still be stopped; without it a
   // quit triggered from the menu or the OS would leave the process tree running.
-  app.on('before-quit', () => {
-    void shutdown()
-  })
+  app.on('before-quit', createBeforeQuitHandler({
+    shutdown,
+    resumeQuit: () => app.quit(),
+    onFailure: (error) => console.error('kernel shutdown failed', error),
+  }))
 }

--- a/src/permission-policy.js
+++ b/src/permission-policy.js
@@ -1,0 +1,10 @@
+/**
+ * The upstream page and its plugins are untrusted. No Chromium permission is granted
+ * implicitly; a future capability needs an explicit reviewed allowlist.
+ *
+ * @param {{setPermissionRequestHandler: (handler: (webContents: unknown, permission: string, callback: (allowed: boolean) => void) => void) => void, setPermissionCheckHandler: (handler: (...args: unknown[]) => boolean) => void}} session
+ */
+export function installDefaultDenyPermissions(session) {
+  session.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
+  session.setPermissionCheckHandler(() => false)
+}

--- a/src/permission-policy.test.js
+++ b/src/permission-policy.test.js
@@ -1,0 +1,25 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { installDefaultDenyPermissions } from './permission-policy.js'
+
+describe('installDefaultDenyPermissions', () => {
+  it('denies every request and synchronous check by default', () => {
+    /** @type {((webContents: unknown, permission: string, callback: (allowed: boolean) => void) => void) | undefined} */
+    let requestHandler
+    /** @type {((...args: unknown[]) => boolean) | undefined} */
+    let checkHandler
+    installDefaultDenyPermissions({
+      setPermissionRequestHandler: (handler) => { requestHandler = handler },
+      setPermissionCheckHandler: (handler) => { checkHandler = handler },
+    })
+    assert.ok(requestHandler)
+    assert.ok(checkHandler)
+    for (const permission of ['media', 'notifications', 'clipboard-read', 'geolocation']) {
+      /** @type {boolean | undefined} */
+      let decision
+      requestHandler({}, permission, (allowed) => { decision = allowed })
+      assert.equal(decision, false)
+      assert.equal(checkHandler({}, permission, 'https://example.test', {}), false)
+    }
+  })
+})

--- a/src/quit-coordinator.js
+++ b/src/quit-coordinator.js
@@ -1,0 +1,26 @@
+/**
+ * Creates Electron's synchronous before-quit handler while keeping shutdown asynchronous.
+ * The first request is stopped; only the coordinator may resume quitting after cleanup.
+ *
+ * @param {{shutdown: () => Promise<void>, resumeQuit: () => void, onFailure?: (error: unknown) => void}} dependencies
+ * @returns {(event: {preventDefault: () => void}) => void}
+ */
+export function createBeforeQuitHandler({ shutdown, resumeQuit, onFailure = () => undefined }) {
+  let phase = 'idle'
+
+  return (event) => {
+    if (phase === 'ready') return
+    event.preventDefault()
+    if (phase === 'stopping') return
+    phase = 'stopping'
+    void shutdown()
+      .then(() => {
+        phase = 'ready'
+        resumeQuit()
+      })
+      .catch((error) => {
+        phase = 'idle'
+        onFailure(error)
+      })
+  }
+}

--- a/src/quit-coordinator.test.js
+++ b/src/quit-coordinator.test.js
@@ -1,0 +1,52 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { createBeforeQuitHandler } from './quit-coordinator.js'
+
+describe('createBeforeQuitHandler', () => {
+  it('blocks the first quit and resumes only after shutdown settles', async () => {
+    /** @type {((value?: void) => void) | undefined} */
+    let release
+    const shutdown = new Promise((resolve) => { release = resolve })
+    let prevented = 0
+    let resumed = 0
+    const handler = createBeforeQuitHandler({
+      shutdown: () => shutdown,
+      resumeQuit: () => { resumed += 1 },
+    })
+
+    handler({ preventDefault: () => { prevented += 1 } })
+    handler({ preventDefault: () => { prevented += 1 } })
+    assert.equal(prevented, 2)
+    assert.equal(resumed, 0)
+
+    assert.ok(release)
+    release()
+    await shutdown
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(resumed, 1)
+
+    handler({ preventDefault: () => { prevented += 1 } })
+    assert.equal(prevented, 2, 'the coordinator must allow the resumed quit through')
+  })
+
+  it('reports cleanup failure, remains alive, and allows an explicit retry', async () => {
+    const failures = []
+    let resumed = 0
+    let attempts = 0
+    const handler = createBeforeQuitHandler({
+      shutdown: async () => {
+        attempts += 1
+        if (attempts === 1) throw new Error('cleanup failed')
+      },
+      resumeQuit: () => { resumed += 1 },
+      onFailure: (error) => failures.push(error),
+    })
+    handler({ preventDefault: () => undefined })
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(failures.length, 1)
+    assert.equal(resumed, 0, 'a failed cleanup must not permit Electron to exit')
+    handler({ preventDefault: () => undefined })
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(resumed, 1)
+  })
+})

--- a/src/runtime-shutdown.js
+++ b/src/runtime-shutdown.js
@@ -1,0 +1,15 @@
+/**
+ * Stops the current runtime and releases ownership only after stop succeeds. Keeping the
+ * identity on failure is what makes a later quit request a real retry rather than a false
+ * success with an orphaned process.
+ *
+ * @param {{getCurrent: () => ({stop: () => Promise<void>} | null), clearIfCurrent: (current: {stop: () => Promise<void>}) => void}} dependencies
+ */
+export function createRuntimeShutdown({ getCurrent, clearIfCurrent }) {
+  return async () => {
+    const current = getCurrent()
+    if (current === null) return
+    await current.stop()
+    clearIfCurrent(current)
+  }
+}

--- a/src/runtime-shutdown.test.js
+++ b/src/runtime-shutdown.test.js
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { createRuntimeShutdown } from './runtime-shutdown.js'
+
+describe('createRuntimeShutdown', () => {
+  it('retains the exact runtime after failure so a retry can stop it', async () => {
+    let attempts = 0
+    const runtime = { stop: async () => { attempts += 1; if (attempts === 1) throw new Error('failed') } }
+    /** @type {typeof runtime | null} */
+    let current = runtime
+    const shutdown = createRuntimeShutdown({
+      getCurrent: () => current,
+      clearIfCurrent: (expected) => { if (current === expected) current = null },
+    })
+    await assert.rejects(shutdown(), /failed/)
+    assert.equal(current, runtime)
+    await shutdown()
+    assert.equal(attempts, 2)
+    assert.equal(current, null)
+  })
+
+  it('does not clear a newer runtime identity', async () => {
+    /** @type {((value?: void) => void) | undefined} */
+    let release
+    const old = { stop: () => new Promise((resolve) => { release = resolve }) }
+    const newer = { stop: async () => undefined }
+    /** @type {typeof old | typeof newer | null} */
+    let current = old
+    const shutdown = createRuntimeShutdown({
+      getCurrent: () => current,
+      clearIfCurrent: (expected) => { if (current === expected) current = null },
+    })
+    const pending = shutdown()
+    current = newer
+    assert.ok(release)
+    release()
+    await pending
+    assert.equal(current, newer)
+  })
+})

--- a/src/startup-current.js
+++ b/src/startup-current.js
@@ -1,0 +1,10 @@
+/**
+ * Re-checks the exact launch after the BrowserWindow is assigned. An exit before this
+ * point must become startup failure, while an exit after it is visible to the registered
+ * unexpected-exit handler because the window already exists.
+ *
+ * @param {{isRunning: () => boolean} | null} running
+ */
+export function assertStartupRuntimeCurrent(running) {
+  if (running === null || !running.isRunning()) throw new Error('The kernel exited before the window was ready.')
+}

--- a/src/startup-current.test.js
+++ b/src/startup-current.test.js
@@ -1,0 +1,11 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { assertStartupRuntimeCurrent } from './startup-current.js'
+
+describe('assertStartupRuntimeCurrent', () => {
+  it('accepts only the exact launch that is still running', () => {
+    assert.doesNotThrow(() => assertStartupRuntimeCurrent({ isRunning: () => true }))
+    assert.throws(() => assertStartupRuntimeCurrent({ isRunning: () => false }), /exited before the window/)
+    assert.throws(() => assertStartupRuntimeCurrent(null), /exited before the window/)
+  })
+})


### PR DESCRIPTION
## What changed

- blocks the first Electron quit request until the exact kernel owner has finished stopping, and retains that identity if cleanup fails so a later quit really retries
- installs default-deny Chromium permission request and permission-check handlers on the production renderer session
- assigns the BrowserWindow before the final exact-runtime liveness check, so an early exit is either startup failure or is visible to the unexpected-exit path
- adds production-module tests plus main.js wiring assertions; no second runtime owner is introduced

## Root causes

PR #7 allowed Electron to exit while asynchronous shutdown was still running, trusted Chromium permission defaults despite treating plugins as untrusted, and had a readiness-to-window race where an exited kernel could leave a dead-origin window.

## Validation

- Node 22 source suite: 58/58 pass, 0 fail, 0 skip
- public-boundary self-test: 11/11
- tracked/history/remote scan: 52 surfaces, 0 findings
- exact head: `227c1925a5cf441acb1c2c48c6daef24285b33a2`
- diff against governance base: 10 files, +229/-14

## Explicit HOLD

This is stacked on governance PR #6 and must not merge first. It remains Draft until real Electron tests witness menu/OS quit waiting, cleanup-failure retry, permission denial, and kernel exit during the readiness-to-window boundary. Existing v0.1.0 assets are not evidence for this fix.
