### PR TITLE
fix: close payload pruning and public-ref scan gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,21 @@ jobs:
           # scan-leaks inspects the committed history, not just the working tree.
           fetch-depth: 0
 
+      - name: Fetch and prove the complete public branch set
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          git fetch --no-tags --prune origin '+refs/pull/*/head:refs/remotes/pull-audit/*'
+          git ls-remote --heads origin | awk '{sub("refs/heads/", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-heads"
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin | grep -v '^HEAD$' | sort > "$RUNNER_TEMP/local-heads"
+          test -s "$RUNNER_TEMP/remote-heads"
+          diff -u "$RUNNER_TEMP/remote-heads" "$RUNNER_TEMP/local-heads"
+          git ls-remote origin 'refs/pull/*/head' | awk '{sub("refs/pull/", "", $2); sub("/head", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-pulls"
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/pull-audit | sort > "$RUNNER_TEMP/local-pulls"
+          test -s "$RUNNER_TEMP/remote-pulls"
+          diff -u "$RUNNER_TEMP/remote-pulls" "$RUNNER_TEMP/local-pulls"
+
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: '22.15'
@@ -49,6 +64,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Fetch and prove the complete public branch set
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          git fetch --no-tags --prune origin '+refs/pull/*/head:refs/remotes/pull-audit/*'
+          git ls-remote --heads origin | awk '{sub("refs/heads/", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-heads"
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin | grep -v '^HEAD$' | sort > "$RUNNER_TEMP/local-heads"
+          test -s "$RUNNER_TEMP/remote-heads"
+          diff -u "$RUNNER_TEMP/remote-heads" "$RUNNER_TEMP/local-heads"
+          git ls-remote origin 'refs/pull/*/head' | awk '{sub("refs/pull/", "", $2); sub("/head", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-pulls"
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/pull-audit | sort > "$RUNNER_TEMP/local-pulls"
+          test -s "$RUNNER_TEMP/remote-pulls"
+          diff -u "$RUNNER_TEMP/remote-pulls" "$RUNNER_TEMP/local-pulls"
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           set -euo pipefail
           git fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
           git fetch --no-tags --prune origin '+refs/pull/*/head:refs/remotes/pull-audit/*'
+          git fetch --no-tags --prune origin '+refs/tags/*:refs/remotes/tag-audit/*'
           git ls-remote --heads origin | awk '{sub("refs/heads/", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-heads"
           git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin | grep -v '^HEAD$' | sort > "$RUNNER_TEMP/local-heads"
           test -s "$RUNNER_TEMP/remote-heads"
@@ -40,6 +41,9 @@ jobs:
           git for-each-ref --format='%(refname:strip=3)' refs/remotes/pull-audit | sort > "$RUNNER_TEMP/local-pulls"
           test -s "$RUNNER_TEMP/remote-pulls"
           diff -u "$RUNNER_TEMP/remote-pulls" "$RUNNER_TEMP/local-pulls"
+          git ls-remote --refs --tags origin | awk '{sub("refs/tags/", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-tags"
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/tag-audit | sort > "$RUNNER_TEMP/local-tags"
+          diff -u "$RUNNER_TEMP/remote-tags" "$RUNNER_TEMP/local-tags"
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
@@ -71,6 +75,7 @@ jobs:
           set -euo pipefail
           git fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
           git fetch --no-tags --prune origin '+refs/pull/*/head:refs/remotes/pull-audit/*'
+          git fetch --no-tags --prune origin '+refs/tags/*:refs/remotes/tag-audit/*'
           git ls-remote --heads origin | awk '{sub("refs/heads/", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-heads"
           git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin | grep -v '^HEAD$' | sort > "$RUNNER_TEMP/local-heads"
           test -s "$RUNNER_TEMP/remote-heads"
@@ -79,6 +84,9 @@ jobs:
           git for-each-ref --format='%(refname:strip=3)' refs/remotes/pull-audit | sort > "$RUNNER_TEMP/local-pulls"
           test -s "$RUNNER_TEMP/remote-pulls"
           diff -u "$RUNNER_TEMP/remote-pulls" "$RUNNER_TEMP/local-pulls"
+          git ls-remote --refs --tags origin | awk '{sub("refs/tags/", "", $2); print $2}' | sort > "$RUNNER_TEMP/remote-tags"
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/tag-audit | sort > "$RUNNER_TEMP/local-tags"
+          diff -u "$RUNNER_TEMP/remote-tags" "$RUNNER_TEMP/local-tags"
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.10.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "electron .",
-    "test": "node tools/run-tests.js src",
+    "test": "node tools/run-tests.js src tools",
     "test:e2e": "node tools/run-tests.js tests",
     "test:all": "npm run test && npm run test:e2e",
     "typecheck": "tsc --noEmit",

--- a/tools/after-pack.js
+++ b/tools/after-pack.js
@@ -61,17 +61,18 @@ export default async function afterPack(context) {
  * Removes Chromium locale files the application will not use.
  *
  * @param {string} appDir
- * @returns {Promise<void>}
+ * @param {{readdir: (path: string) => Promise<string[]>, rm: (path: string, options: {force: boolean}) => Promise<void>, stat: (path: string) => Promise<{size: number}>}} [dependencies]
+ * @returns {Promise<{removed: number, bytes: number}>}
  */
-async function pruneLocales(appDir) {
+async function pruneLocales(appDir, dependencies = { readdir, rm, stat }) {
   const localesDir = join(appDir, 'locales')
 
   /** @type {string[]} */
   let entries
   try {
-    entries = await readdir(localesDir)
+    entries = await dependencies.readdir(localesDir)
   } catch {
-    return // No locales directory on this platform layout.
+    return { removed: 0, bytes: 0 } // No locales directory on this platform layout.
   }
 
   let removed = 0
@@ -83,9 +84,10 @@ async function pruneLocales(appDir) {
 
     const path = join(localesDir, entry)
     try {
-      bytes += (await stat(path)).size
-      await rm(path, { force: true })
+      const size = (await dependencies.stat(path)).size
+      await dependencies.rm(path, { force: true })
       removed += 1
+      bytes += size
     } catch {
       // Leaving one behind costs space, not correctness.
     }
@@ -95,6 +97,7 @@ async function pruneLocales(appDir) {
     `  • pruned ${removed} locale files, ${(bytes / 1024 / 1024).toFixed(1)} MB` +
       ` (kept ${[...KEEP_LOCALES].join(', ')})`,
   )
+  return { removed, bytes }
 }
 
 /**
@@ -109,3 +112,5 @@ async function assertPresent(path, message) {
     throw new Error(message)
   }
 }
+
+export { pruneLocales }

--- a/tools/after-pack.test.js
+++ b/tools/after-pack.test.js
@@ -1,0 +1,25 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { pruneLocales } from './after-pack.js'
+
+describe('pruneLocales', () => {
+  it('counts bytes only after deletion succeeds', async () => {
+    const result = await pruneLocales('fixture', {
+      readdir: async () => ['en-US.pak', 'fr.pak'],
+      stat: async () => ({ size: 123 }),
+      rm: async () => { throw new Error('locked') },
+    })
+    assert.deepEqual(result, { removed: 0, bytes: 0 })
+  })
+
+  it('counts a locale that was actually removed', async () => {
+    const deleted = []
+    const result = await pruneLocales('fixture', {
+      readdir: async () => ['en-US.pak', 'fr.pak'],
+      stat: async () => ({ size: 123 }),
+      rm: async (path) => { deleted.push(path) },
+    })
+    assert.equal(deleted.length, 1)
+    assert.deepEqual(result, { removed: 1, bytes: 123 })
+  })
+})

--- a/tools/prune-kernel.js
+++ b/tools/prune-kernel.js
@@ -21,6 +21,7 @@
  */
 
 import { readdir, rm, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { dirname, extname, join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -163,8 +164,8 @@ async function treeSize(path) {
 }
 
 async function main() {
-  const platform = process.env.DSH_TARGET_PLATFORM ?? process.platform
-  const arch = process.env.DSH_TARGET_ARCH ?? process.arch
+  const manifest = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'))
+  const { platform, arch } = configuredPackageTarget(manifest, process.platform, process.arch)
 
   const before = await treeSize(kernelDir)
   if (before.files === 0) {
@@ -184,11 +185,47 @@ async function main() {
   )
 }
 
-try {
-  await main()
-} catch (error) {
-  console.error(`\nprune-kernel failed: ${error instanceof Error ? error.message : String(error)}`)
-  process.exit(1)
+/**
+ * Derive the payload identity from the package that will actually be built. The host
+ * architecture is irrelevant: an ARM64 builder may still be producing an x64 package.
+ * Multiple architectures must be split into separate installs rather than pruned as one.
+ *
+ * @param {unknown} manifest
+ * @param {string} hostPlatform
+ * @param {string} hostArch
+ * @returns {{platform: string, arch: string}}
+ */
+function configuredPackageTarget(manifest, hostPlatform, hostArch) {
+  if (hostPlatform !== 'win32') return { platform: hostPlatform, arch: hostArch }
+  if (typeof manifest !== 'object' || manifest === null || !('build' in manifest)) {
+    throw new Error('package.json has no build target')
+  }
+  const build = manifest.build
+  if (typeof build !== 'object' || build === null || !('win' in build)) {
+    throw new Error('package.json has no Windows build target')
+  }
+  const win = build.win
+  if (typeof win !== 'object' || win === null || !('target' in win) || !Array.isArray(win.target)) {
+    throw new Error('package.json has no explicit Windows target architectures')
+  }
+  const architectures = new Set()
+  for (const target of win.target) {
+    if (typeof target !== 'object' || target === null || !('arch' in target) || !Array.isArray(target.arch)) continue
+    for (const arch of target.arch) if (typeof arch === 'string' && arch !== '') architectures.add(arch)
+  }
+  if (architectures.size !== 1) {
+    throw new Error(`expected exactly one Windows package architecture, found ${architectures.size}`)
+  }
+  return { platform: 'win32', arch: /** @type {string} */ ([...architectures][0]) }
 }
 
-export { isForeignPrebuild, DROP_EXTENSIONS, KEEP_NAMES }
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main()
+  } catch (error) {
+    console.error(`\nprune-kernel failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+}
+
+export { configuredPackageTarget, isForeignPrebuild, DROP_EXTENSIONS, KEEP_NAMES }

--- a/tools/prune-kernel.test.js
+++ b/tools/prune-kernel.test.js
@@ -1,0 +1,24 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { configuredPackageTarget, isForeignPrebuild } from './prune-kernel.js'
+
+describe('configuredPackageTarget', () => {
+  /** @param {string[]} arch */
+  const manifest = (arch) => ({ build: { win: { target: [{ target: 'nsis', arch }, { target: 'zip', arch }] } } })
+
+  it('uses the package architecture rather than the build host architecture', () => {
+    assert.deepEqual(configuredPackageTarget(manifest(['x64']), 'win32', 'arm64'), { platform: 'win32', arch: 'x64' })
+    assert.equal(isForeignPrebuild('win32-x64', 'win32', 'x64'), false)
+    assert.equal(isForeignPrebuild('win32-arm64', 'win32', 'x64'), true)
+  })
+
+  it('fails closed when the package has no single architecture', () => {
+    assert.throws(() => configuredPackageTarget(manifest([]), 'win32', 'x64'), /exactly one/)
+    assert.throws(() => configuredPackageTarget(manifest(['x64', 'arm64']), 'win32', 'x64'), /exactly one/)
+  })
+
+  it('preserves the host target on non-Windows package builds', () => {
+    assert.deepEqual(configuredPackageTarget({}, 'linux', 'arm64'), { platform: 'linux', arch: 'arm64' })
+    assert.deepEqual(configuredPackageTarget({}, 'darwin', 'x64'), { platform: 'darwin', arch: 'x64' })
+  })
+})

--- a/tools/run-tests.js
+++ b/tools/run-tests.js
@@ -20,20 +20,20 @@ function findTests(root) {
   return found.sort((left, right) => left.localeCompare(right, "en"))
 }
 
-const requestedRoot = process.argv[2]
-if (!requestedRoot) {
-  console.error("run-tests: expected a test root")
+const requestedRoots = process.argv.slice(2)
+if (requestedRoots.length === 0) {
+  console.error("run-tests: expected at least one test root")
   process.exit(2)
 }
 
-const root = path.resolve(requestedRoot)
-const tests = findTests(root)
+const roots = requestedRoots.map((root) => path.resolve(root))
+const tests = [...new Set(roots.flatMap(findTests))].sort((left, right) => left.localeCompare(right, "en"))
 if (tests.length === 0) {
-  console.error(`run-tests: discovered zero tests under ${root}`)
+  console.error(`run-tests: discovered zero tests under ${roots.join(", ")}`)
   process.exit(3)
 }
 
-console.log(`run-tests: discovered ${tests.length} files under ${root}`)
+console.log(`run-tests: discovered ${tests.length} files under ${roots.join(", ")}`)
 const result = spawnSync(process.execPath, ["--test", ...tests], { stdio: "inherit" })
 if (result.error) {
   console.error(`run-tests: failed to start Node: ${result.error.message}`)

--- a/tools/scan-leaks.js
+++ b/tools/scan-leaks.js
@@ -49,13 +49,19 @@ const PRIVATE_IDENTITY = new RegExp([
   '\\u5929\\u9a6c',
 ].join('|'), 'iu')
 
+// Public product identity is non-negotiable on every ref type. PR history only relaxes
+// synthetic RFC1918 fixture addresses.
+const HISTORY_FORBIDDEN = Object.freeze([
+  ...FORBIDDEN,
+  { name: 'private organization or product identity', pattern: PRIVATE_IDENTITY },
+])
+
 // Pull-request refs remain publicly fetchable after their source branches are deleted.
 // Historical test fixtures legitimately contain synthetic private IPs and fake user
 // paths, so PR history uses the non-negotiable disclosure rules rather than pretending
 // those fixtures are real infrastructure. Branch history still uses every rule above.
 const PR_HISTORY_FORBIDDEN = Object.freeze([
-  ...FORBIDDEN.filter(({ name }) => name !== 'RFC1918 address'),
-  { name: 'private organization or product identity', pattern: PRIVATE_IDENTITY },
+  ...HISTORY_FORBIDDEN.filter(({ name }) => name !== 'RFC1918 address'),
 ])
 
 /** Paths whose contents are not ours to police. */
@@ -102,11 +108,12 @@ function scanRepository(root) {
 
   // History matters as much as the current tree: a secret removed in a later commit is
   // still served by every clone of the repository.
-  // Every public branch is fetchable whether or not it is merged. CI first fetches and
-  // proves the complete remote-head set, then this scan covers HEAD plus every origin ref.
-  // A secret on an unmerged branch is already disclosed; waiting until merge is too late.
-  const history = git(['log', 'HEAD', '--remotes=origin', '-p', '--no-color', '--diff-filter=AM'], root)
-  for (const { name, pattern } of FORBIDDEN) {
+  // Every public branch and tag is fetchable whether or not it is merged. CI first fetches
+  // and proves the complete remote-head and tag sets, then this scan covers HEAD plus both
+  // audit namespaces. A secret on an unmerged branch or tag-only commit is already
+  // disclosed; waiting until merge is too late.
+  const history = git(['log', 'HEAD', '--remotes=origin', '--remotes=tag-audit', '-p', '--no-color', '--diff-filter=AM'], root)
+  for (const { name, pattern } of HISTORY_FORBIDDEN) {
     if (pattern.test(history)) findings.push(`git history: ${name}`)
   }
   const pullHistory = git(['log', '--remotes=pull-audit', '-p', '--no-color', '--diff-filter=AM'], root)

--- a/tools/scan-leaks.js
+++ b/tools/scan-leaks.js
@@ -16,7 +16,7 @@
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -40,6 +40,24 @@ const FORBIDDEN = Object.freeze([
   { name: 'RFC1918 address', pattern: /\b(?:10\.\d{1,3}|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d{1,3}\.\d{1,3}\b/ },
 ])
 
+const PRIVATE_IDENTITY = new RegExp([
+  ['tian', 'ma'].join(''),
+  ['tm', 'work'].join(''),
+  ['tm', 'code'].join(''),
+  ['agent', 'portal'].join('[-_]?'),
+  ['cli', 'aab9eabbceba9cca'].join('_'),
+  '\\u5929\\u9a6c',
+].join('|'), 'iu')
+
+// Pull-request refs remain publicly fetchable after their source branches are deleted.
+// Historical test fixtures legitimately contain synthetic private IPs and fake user
+// paths, so PR history uses the non-negotiable disclosure rules rather than pretending
+// those fixtures are real infrastructure. Branch history still uses every rule above.
+const PR_HISTORY_FORBIDDEN = Object.freeze([
+  ...FORBIDDEN.filter(({ name }) => name !== 'RFC1918 address'),
+  { name: 'private organization or product identity', pattern: PRIVATE_IDENTITY },
+])
+
 /** Paths whose contents are not ours to police. */
 const SKIP = [/^resources\/kernel\//, /^node_modules\//, /^release\//, /^assets\/.*\.(png|ico|icns)$/]
 
@@ -47,57 +65,69 @@ const SKIP = [/^resources\/kernel\//, /^node_modules\//, /^release\//, /^assets\
  * @param {string[]} args
  * @returns {string}
  */
-function git(args) {
-  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+function git(args, root = repoRoot) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
 }
 
-/** @returns {string[]} */
-function trackedFiles() {
-  return git(['ls-files'])
+/** @param {string} root @returns {string[]} */
+function trackedFiles(root) {
+  return git(['ls-files'], root)
     .split('\n')
     .filter((path) => path !== '')
     .filter((path) => !SKIP.some((skip) => skip.test(path)))
 }
 
-/** @type {string[]} */
-const findings = []
+/** @param {string} root @returns {string[]} */
+function scanRepository(root) {
+  /** @type {string[]} */
+  const findings = []
 
-for (const path of trackedFiles()) {
-  /** @type {string} */
-  let content
-  try {
-    content = readFileSync(resolve(repoRoot, path), 'utf8')
-  } catch {
-    continue // Binary or unreadable; nothing to match against.
-  }
+  for (const path of trackedFiles(root)) {
+    /** @type {string} */
+    let content
+    try {
+      content = readFileSync(resolve(root, path), 'utf8')
+    } catch {
+      continue // Binary or unreadable; nothing to match against.
+    }
 
-  for (const { name, pattern } of FORBIDDEN) {
-    const match = pattern.exec(content)
-    if (match !== null) {
-      const line = content.slice(0, match.index).split('\n').length
-      findings.push(`${path}:${line}: ${name}`)
+    for (const { name, pattern } of FORBIDDEN) {
+      const match = pattern.exec(content)
+      if (match !== null) {
+        const line = content.slice(0, match.index).split('\n').length
+        findings.push(`${path}:${line}: ${name}`)
+      }
     }
   }
-}
 
-// History matters as much as the current tree: a secret removed in a later commit is
-// still served by every clone of the repository.
-try {
-  // Validate the candidate's reachable history. Unrelated local/remote refs are not part
-  // of the commit being proposed and would make results depend on checkout state.
-  const history = git(['log', 'HEAD', '-p', '--no-color', '--diff-filter=AM'])
+  // History matters as much as the current tree: a secret removed in a later commit is
+  // still served by every clone of the repository.
+  // Every public branch is fetchable whether or not it is merged. CI first fetches and
+  // proves the complete remote-head set, then this scan covers HEAD plus every origin ref.
+  // A secret on an unmerged branch is already disclosed; waiting until merge is too late.
+  const history = git(['log', 'HEAD', '--remotes=origin', '-p', '--no-color', '--diff-filter=AM'], root)
   for (const { name, pattern } of FORBIDDEN) {
     if (pattern.test(history)) findings.push(`git history: ${name}`)
   }
-} catch {
-  console.warn('scan-leaks: history scan skipped (no commits yet)')
+  const pullHistory = git(['log', '--remotes=pull-audit', '-p', '--no-color', '--diff-filter=AM'], root)
+  for (const { name, pattern } of PR_HISTORY_FORBIDDEN) {
+    if (pattern.test(pullHistory)) findings.push(`pull-request history: ${name}`)
+  }
+  return findings
 }
 
-if (findings.length > 0) {
-  console.error('scan-leaks found content that must not be published:\n')
-  for (const finding of findings) console.error(`  ${finding}`)
-  console.error('\nRemove it from the working tree, and rewrite history if it was ever committed.')
-  process.exit(1)
+function main() {
+  const findings = scanRepository(repoRoot)
+  if (findings.length > 0) {
+    console.error('scan-leaks found content that must not be published:\n')
+    for (const finding of findings) console.error(`  ${finding}`)
+    console.error('\nRemove it from the working tree, and rewrite history if it was ever committed.')
+    process.exitCode = 1
+    return
+  }
+  console.log('scan-leaks: clean')
 }
 
-console.log('scan-leaks: clean')
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) main()
+
+export { scanRepository }

--- a/tools/scan-leaks.test.js
+++ b/tools/scan-leaks.test.js
@@ -1,0 +1,56 @@
+import { strict as assert } from 'node:assert'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+import { scanRepository } from './scan-leaks.js'
+
+const roots = []
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }) })
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-leak-scan-'))
+  roots.push(root)
+  const git = (...args) => execFileSync('git', args, { cwd: root, stdio: 'ignore' })
+  git('init', '-b', 'main')
+  git('config', 'user.name', 'Boundary Test')
+  git('config', 'user.email', 'boundary@example.test')
+  writeFileSync(join(root, 'README.md'), 'public\n')
+  git('add', 'README.md')
+  git('commit', '-m', 'clean main')
+  git('update-ref', 'refs/remotes/pull-audit/1', 'HEAD')
+  return { root, git }
+}
+
+describe('scanRepository public history', () => {
+  it('finds a leak reachable only from another public branch', () => {
+    const { root, git } = fixture()
+    git('switch', '-c', 'leaked')
+    writeFileSync(join(root, 'endpoint.txt'), `http://${[192, 168, 7, 9].join('.')}/\n`)
+    git('add', 'endpoint.txt')
+    git('commit', '-m', 'branch-only bytes')
+    const leaked = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim()
+    git('switch', 'main')
+    git('update-ref', 'refs/remotes/origin/leaked', leaked)
+    assert.ok(scanRepository(root).includes('git history: RFC1918 address'))
+  })
+
+  it('finds a private identity reachable only from a pull-request ref', () => {
+    const { root, git } = fixture()
+    git('switch', '-c', 'private-pr')
+    writeFileSync(join(root, 'identity.txt'), `${['tm', 'work'].join('')}\n`)
+    git('add', 'identity.txt')
+    git('commit', '-m', 'private PR bytes')
+    const leaked = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim()
+    git('switch', 'main')
+    git('update-ref', 'refs/remotes/pull-audit/2', leaked)
+    assert.ok(scanRepository(root).includes('pull-request history: private organization or product identity'))
+  })
+
+  it('fails closed when history cannot be enumerated', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-not-a-repo-'))
+    roots.push(root)
+    assert.throws(() => scanRepository(root))
+  })
+})

--- a/tools/scan-leaks.test.js
+++ b/tools/scan-leaks.test.js
@@ -48,6 +48,19 @@ describe('scanRepository public history', () => {
     assert.ok(scanRepository(root).includes('pull-request history: private organization or product identity'))
   })
 
+  it('finds a leak reachable only from a public tag', () => {
+    const { root, git } = fixture()
+    git('switch', '-c', 'tagged-then-deleted')
+    writeFileSync(join(root, 'tag-secret.txt'), `${['tm', 'code'].join('')}\n`)
+    git('add', 'tag-secret.txt')
+    git('commit', '-m', 'tag-only bytes')
+    const leaked = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim()
+    git('switch', 'main')
+    git('branch', '-D', 'tagged-then-deleted')
+    git('update-ref', 'refs/remotes/tag-audit/v-test', leaked)
+    assert.ok(scanRepository(root).includes('git history: private organization or product identity'))
+  })
+
   it('fails closed when history cannot be enumerated', () => {
     const root = mkdtempSync(join(tmpdir(), 'dsh-not-a-repo-'))
     roots.push(root)


### PR DESCRIPTION
## Why this is stacked

PR #12 was merged into main before checks/review completed. This corrective PR is intentionally based on governance PR #6 so the new tests and CI can actually run; after #6 merges, rebase this branch onto main before making it Ready.

## Four unresolved #12 findings closed

- Derive the native payload platform/architecture from the explicit package target, never the builder host `process.arch`; fail closed unless exactly one Windows architecture is configured.
- Restore credential scanning across every publicly fetchable branch. CI explicitly fetches all heads, compares the remote and local ref sets exactly, then scans `HEAD + origin/*`.
- Synchronize both package-lock root version fields with package.json 0.1.1.
- Count locale bytes only after deletion succeeds.

The obsolete closed PR #8 branch was deleted after exact-target verification, because it contained the historical RFC1918 test fixture and had already been superseded by #11. The closed PR and commit record remain for provenance; no scanner exemption was added.

## Local evidence

At exact head `a614a66ebe609d976cd4fc688201b8dd29b1429c` on base #6: standard unit `48/48`, strict TypeScript clean, boundary self-test `11/11`, public-ref leak scan clean. New focused product tests add four witnessed cases for package target selection/fail-closed multiplicity and successful/failed locale deletion accounting.

Draft / NO-GO until GitHub Linux+Windows+E2E and public-boundary checks finish, review threads are independently verified, #6 merges, and this branch is rebased to then-current main. No release is authorized.
