### PR TITLE
Release 0.1.3 so the notarized Mac build has its own filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] — 2026-08-14
+
+### Changed
+
+- The macOS Apple Silicon `.dmg` / `.zip` is a **new version**, not a replacement of the
+  `v0.1.2` filename. `v0.1.2` briefly had two different binaries under the same name
+  (first ad-hoc, then Developer ID). Use `v0.1.3` for the notarized build.
+- Packaging drops `node_modules/.bin` from the bundled kernel. Those npm shims are
+  absolute links to the build machine; leaving them in the `.app` makes
+  `codesign --verify --deep` fail.
+
+### Added
+
+- Developer ID signature and Apple notarization on the Apple Silicon package.
+  Gatekeeper reports `Notarized Developer ID`. The ticket is stapled to the `.app`.
+
 ## [0.1.2] — 2026-08-14
 
 ### Added
@@ -79,6 +95,7 @@ First preview. Windows is built and verified end to end; macOS and Linux are unt
 - Log redaction matches by shape and cannot be complete.
 - Installers are unsigned, so Windows SmartScreen will warn on first run.
 
+[0.1.3]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.3
 [0.1.2]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.2
 [0.1.1]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.1
 [0.1.0]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Unsigned, so SmartScreen will warn on first run. The current Windows drop is sti
 
 [All releases][releases]
 
-[mac-dmg]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/download/v0.1.2/DeepSeek-Harness-Desktop-0.1.2-arm64.dmg
-[mac-zip]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/download/v0.1.2/DeepSeek-Harness-Desktop-0.1.2-arm64.zip
+[mac-dmg]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/download/v0.1.3/DeepSeek-Harness-Desktop-0.1.3-arm64.dmg
+[mac-zip]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/download/v0.1.3/DeepSeek-Harness-Desktop-0.1.3-arm64.zip
 [win-exe]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/download/v0.1.1/DeepSeek-Harness-Desktop-0.1.1-x64.exe
 [win-zip]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/download/v0.1.1/DeepSeek-Harness-Desktop-0.1.1-x64.zip
 [releases]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases
@@ -181,7 +181,7 @@ they can be tested directly:
 
 ### macOS notes
 
-The [v0.1.2](https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.2)
+The [v0.1.3](https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.3)
 Apple Silicon build is signed with Developer ID Application and notarized by Apple.
 Gatekeeper should accept it without a right-click override. The ticket is stapled to the
 `.app`; the `.dmg` itself is not separately stapled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-desktop",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "productName": "DeepSeek Harness Desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Desktop shell for the DeepSeek Harness (dsh) agent runtime.",
   "license": "MIT",
   "type": "module",
@@ -78,6 +78,7 @@
       "gatekeeperAssess": false,
       "entitlements": "assets/entitlements.mac.plist",
       "entitlementsInherit": "assets/entitlements.mac.plist",
+      "notarize": true,
       "target": ["dmg", "zip"]
     },
     "dmg": {

--- a/tools/after-pack.js
+++ b/tools/after-pack.js
@@ -48,6 +48,13 @@ export default async function afterPack(context) {
   console.log(`  • copying kernel  from=${source} to=${destination}`)
   await cp(source, destination, { recursive: true, force: true })
 
+  // npm writes .bin shims as absolute links into the *source* tree. Copied
+  // into the .app they still point at the build machine, and codesign
+  // --verify --deep fails with "invalid destination for symbolic link".
+  // The shell invokes lib/bin.js directly, so the shims are unused.
+  await rm(join(destination, 'node_modules', '.bin'), { recursive: true, force: true })
+  console.log('  • dropped kernel node_modules/.bin (absolute npm shims cannot be signed)')
+
   // Read back the one file the application actually spawns.
   const binPath = join(destination, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')
   await assertPresent(binPath, `the kernel entry point is missing from the package at ${binPath}`)

--- a/tools/after-pack.js
+++ b/tools/after-pack.js
@@ -53,7 +53,7 @@ export default async function afterPack(context) {
   // --verify --deep fails with "invalid destination for symbolic link".
   // The shell invokes lib/bin.js directly, so every .bin directory is unused.
   const dropped = await dropNpmBinDirs(join(destination, 'node_modules'))
-  console.log(`  • dropped ${dropped} kernel node_modules/**/.bin dir(s) (absolute npm shims cannot be signed)`)
+  console.log(`  • dropped ${dropped} kernel .bin dir(s) (absolute npm shims cannot be signed)`)
 
   // Read back the one file the application actually spawns.
   const binPath = join(destination, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')
@@ -75,7 +75,7 @@ export default async function afterPack(context) {
 }
 
 /**
- * Removes every `node_modules/**/.bin` directory under `root`.
+ * Removes every `.bin` directory anywhere under a `node_modules` tree.
  *
  * @param {string} root
  * @returns {Promise<number>}

--- a/tools/after-pack.js
+++ b/tools/after-pack.js
@@ -51,9 +51,9 @@ export default async function afterPack(context) {
   // npm writes .bin shims as absolute links into the *source* tree. Copied
   // into the .app they still point at the build machine, and codesign
   // --verify --deep fails with "invalid destination for symbolic link".
-  // The shell invokes lib/bin.js directly, so the shims are unused.
-  await rm(join(destination, 'node_modules', '.bin'), { recursive: true, force: true })
-  console.log('  • dropped kernel node_modules/.bin (absolute npm shims cannot be signed)')
+  // The shell invokes lib/bin.js directly, so every .bin directory is unused.
+  const dropped = await dropNpmBinDirs(join(destination, 'node_modules'))
+  console.log(`  • dropped ${dropped} kernel node_modules/**/.bin dir(s) (absolute npm shims cannot be signed)`)
 
   // Read back the one file the application actually spawns.
   const binPath = join(destination, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')
@@ -72,6 +72,35 @@ export default async function afterPack(context) {
   console.log('  • kernel copied and verified')
 
   await pruneLocales(isMac ? join(resourcesDir, '..', 'Resources') : context.appOutDir)
+}
+
+/**
+ * Removes every `node_modules/**/.bin` directory under `root`.
+ *
+ * @param {string} root
+ * @returns {Promise<number>}
+ */
+async function dropNpmBinDirs(root) {
+  let dropped = 0
+  /** @type {import('node:fs').Dirent[]} */
+  let entries
+  try {
+    entries = await readdir(root, { withFileTypes: true })
+  } catch {
+    return 0
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const path = join(root, entry.name)
+    if (entry.name === '.bin') {
+      await rm(path, { recursive: true, force: true })
+      dropped += 1
+      continue
+    }
+    dropped += await dropNpmBinDirs(path)
+  }
+  return dropped
 }
 
 /**


### PR DESCRIPTION
v0.1.2 used the same dmg filename for an ad-hoc build and then a Developer ID rebuild. 0.1.3 is a new version for the notarized Apple Silicon package, drops the absolute npm .bin shims that break codesign, and points the README at the new files.