### PR TITLE
Add macOS tray icon and background running support

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "assets/entitlements.mac.plist",
+      "extraResources": [
+        "assets/icon.png"
+      ],
       "entitlementsInherit": "assets/entitlements.mac.plist",
       "notarize": true,
       "target": ["dmg", "zip"]

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ import { existsSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { app, BrowserWindow, dialog, shell } from 'electron'
+import { app, BrowserWindow, dialog, shell, ipcMain } from 'electron'
 import { KernelProcess, findFreePort } from './kernel-process.js'
 import { buildKernelArgs, buildKernelEnv, isSupportedNodeVersion } from './kernel-runtime.js'
 import { nodeBinaryName } from './node-runtime.js'
@@ -25,6 +25,7 @@ import {
   isAllowedNavigation,
   kernelOrigin,
 } from './window-policy.js'
+import { createTray, showTaskNotification, destroyTray } from './tray.js'
 
 const HOST = '127.0.0.1'
 const here = dirname(fileURLToPath(import.meta.url))
@@ -33,6 +34,8 @@ const here = dirname(fileURLToPath(import.meta.url))
 let kernel = null
 /** @type {BrowserWindow | null} */
 let mainWindow = null
+/** @type {boolean} */
+let isQuitting = false
 
 /**
  * Where the bundled kernel lives, packaged or not.
@@ -185,6 +188,13 @@ function createWindow(origin) {
   })
 
   window.once('ready-to-show', () => window.show())
+  window.on('close', (event) => {
+    // Only hide if not quitting (not dock quit)
+    if (!isQuitting && process.platform === 'darwin') {
+      event.preventDefault()
+      window.hide()
+    }
+  })
   window.on('closed', () => {
     mainWindow = null
   })
@@ -224,6 +234,12 @@ if (!app.requestSingleInstanceLock()) {
     try {
       const { origin } = await startKernel()
       mainWindow = createWindow(origin)
+      createTray(mainWindow)
+
+      // IPC handler for renderer to notify task completion
+      ipcMain.on('task-complete', (_event, { title, body }) => {
+        showTaskNotification(title || 'Task Complete', body || 'DeepSeek task has finished.')
+      })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
 
@@ -245,10 +261,9 @@ if (!app.requestSingleInstanceLock()) {
     }
   })
 
-  // The kernel is a child of this process. macOS would normally keep the app
-  // alive with no windows; that would leave the kernel running invisibly in
-  // the Dock. Quit on last close on every platform.
+  // The kernel is a child of this process. Quit on last close on all platforms.
   app.on('window-all-closed', async () => {
+    isQuitting = true
     await shutdown()
     app.quit()
   })
@@ -262,6 +277,8 @@ if (!app.requestSingleInstanceLock()) {
   // `before-quit` is the last point at which the kernel can still be stopped; without it a
   // quit triggered from the menu or the OS would leave the process tree running.
   app.on('before-quit', () => {
+    isQuitting = true
+    destroyTray()
     void shutdown()
   })
 }

--- a/src/tray.js
+++ b/src/tray.js
@@ -1,0 +1,116 @@
+/**
+ * System tray management for macOS.
+ *
+ * @module tray
+ */
+
+import { Tray, Menu, nativeImage, Notification, app } from 'electron'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+/** @type {Tray | null} */
+let tray = null
+
+/** @type {import('electron').BrowserWindow | null} */
+let mainWindowRef = null
+
+/**
+ * Get the correct path to the icon, handling both dev and packaged scenarios.
+ * @returns {string}
+ */
+function getIconPath() {
+  if (app.isPackaged) {
+    // In packaged app, extraResources puts files in Contents/Resources/
+    return join(process.resourcesPath, 'assets', 'icon.png')
+  }
+  return join(here, '..', 'assets', 'icon.png')
+}
+
+/**
+ * @param {import('electron').BrowserWindow} window
+ */
+export function createTray(window) {
+  mainWindowRef = window
+
+  // Use the app icon as tray icon
+  const iconPath = getIconPath()
+  const icon = nativeImage.createFromPath(iconPath)
+
+  // Resize for tray (16x16 on macOS)
+  const trayIcon = icon.resize({ width: 16, height: 16 })
+
+  tray = new Tray(trayIcon)
+  tray.setToolTip('DeepSeek Harness Desktop')
+
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Show Window',
+      click: () => {
+        if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+          mainWindowRef.show()
+          mainWindowRef.focus()
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit',
+      click: () => {
+        // Use app.quit() to trigger proper quit flow
+        app.quit()
+      },
+    },
+  ])
+
+  tray.setContextMenu(contextMenu)
+
+  // Click on tray icon shows window
+  tray.on('click', () => {
+    if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+      if (mainWindowRef.isVisible()) {
+        mainWindowRef.focus()
+      } else {
+        mainWindowRef.show()
+      }
+    }
+  })
+
+  return tray
+}
+
+/**
+ * Show a notification when a task completes.
+ *
+ * @param {string} title
+ * @param {string} body
+ */
+export function showTaskNotification(title, body) {
+  if (!Notification.isSupported()) return
+
+  const notification = new Notification({
+    title,
+    body,
+    silent: false,
+  })
+
+  notification.on('click', () => {
+    if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+      mainWindowRef.show()
+      mainWindowRef.focus()
+    }
+  })
+
+  notification.show()
+}
+
+/**
+ * Destroy the tray instance.
+ */
+export function destroyTray() {
+  if (tray) {
+    tray.destroy()
+    tray = null
+  }
+}


### PR DESCRIPTION
- Add system tray icon using app icon
- Hide window to tray on close (macOS)
- Show window from tray on click
- Add task completion notifications via IPC
- Fix dock hiding behavior and quit flow
- Move icon.png to extraResources for packaged app