### PR TITLE
Ship 0.1.4: testable tray helpers on the hide-vs-quit path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] — 2026-08-16
+
+### Added
+
+- macOS tray: closing the window hides the app instead of quitting, so the kernel
+  keeps running. Quit from the tray menu, Dock, or Cmd+Q still stops the kernel
+  process tree. Tray icon path and hide-vs-quit are decided by testable helpers
+  (`resolveTrayIconPath`, `shouldHideOnClose`).
+
+### Changed
+
+- This is a new tag, not a replacement of `v0.1.2`. Keep using `v0.1.2` for the
+  known-good notarized Mac download if this drop is unsigned or a `.dmg` is
+  reported damaged.
+
 ## [0.1.3] — 2026-08-14
 
 ### Changed
@@ -95,6 +110,7 @@ First preview. Windows is built and verified end to end; macOS and Linux are unt
 - Log redaction matches by shape and cannot be complete.
 - Installers are unsigned, so Windows SmartScreen will warn on first run.
 
+[0.1.4]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.4
 [0.1.3]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.3
 [0.1.2]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.2
 [0.1.1]: https://github.com/sleep2agi/DeepSeek-Harness-Desktop/releases/tag/v0.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepseek-harness-desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-desktop",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-harness-desktop",
   "productName": "DeepSeek Harness Desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Desktop shell for the DeepSeek Harness (dsh) agent runtime.",
   "license": "MIT",
   "type": "module",

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ import {
   isAllowedNavigation,
   kernelOrigin,
 } from './window-policy.js'
-import { createTray, showTaskNotification, destroyTray } from './tray.js'
+import { createTray, destroyTray, shouldHideOnClose, showTaskNotification } from './tray.js'
 
 const HOST = '127.0.0.1'
 const here = dirname(fileURLToPath(import.meta.url))
@@ -189,8 +189,7 @@ function createWindow(origin) {
 
   window.once('ready-to-show', () => window.show())
   window.on('close', (event) => {
-    // Only hide if not quitting (not dock quit)
-    if (!isQuitting && process.platform === 'darwin') {
+    if (shouldHideOnClose({ isQuitting, platform: process.platform })) {
       event.preventDefault()
       window.hide()
     }

--- a/src/tray.js
+++ b/src/tray.js
@@ -1,37 +1,77 @@
 /**
  * System tray management for macOS.
  *
+ * Icon path and hide-vs-quit are decided here so they can be tested without a
+ * real Tray. Electron APIs are loaded only when creating the tray, because this
+ * module is also imported by `node --test`.
+ *
  * @module tray
  */
 
-import { Tray, Menu, nativeImage, Notification, app } from 'electron'
-import { join, dirname } from 'node:path'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
+const requireFromHere = createRequire(import.meta.url)
 
-/** @type {Tray | null} */
+/** @type {import('electron').Tray | null} */
 let tray = null
 
 /** @type {import('electron').BrowserWindow | null} */
 let mainWindowRef = null
 
 /**
- * Get the correct path to the icon, handling both dev and packaged scenarios.
+ * Packaged `extraResources` copies `assets/icon.png` under `Contents/Resources/assets/`.
+ *
+ * @param {object} options
+ * @param {boolean} options.isPackaged
+ * @param {string} options.resourcesPath
+ * @param {string} options.projectRoot
+ * @returns {string}
+ */
+export function resolveTrayIconPath({ isPackaged, resourcesPath, projectRoot }) {
+  if (isPackaged) {
+    return join(resourcesPath, 'assets', 'icon.png')
+  }
+  return join(projectRoot, 'assets', 'icon.png')
+}
+
+/**
+ * Closing the last window on macOS hides to the tray unless we are already quitting.
+ * Quit still goes through `before-quit` / `window-all-closed` and stops the kernel.
+ *
+ * @param {object} options
+ * @param {boolean} options.isQuitting
+ * @param {string} options.platform
+ * @returns {boolean}
+ */
+export function shouldHideOnClose({ isQuitting, platform }) {
+  return !isQuitting && platform === 'darwin'
+}
+
+/**
  * @returns {string}
  */
 function getIconPath() {
-  if (app.isPackaged) {
-    // In packaged app, extraResources puts files in Contents/Resources/
-    return join(process.resourcesPath, 'assets', 'icon.png')
-  }
-  return join(here, '..', 'assets', 'icon.png')
+  const { app } = electronApi()
+  return resolveTrayIconPath({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    projectRoot: join(here, '..'),
+  })
+}
+
+/** @returns {typeof import('electron')} */
+function electronApi() {
+  return requireFromHere('electron')
 }
 
 /**
  * @param {import('electron').BrowserWindow} window
  */
 export function createTray(window) {
+  const { Tray, Menu, nativeImage, app } = electronApi()
   mainWindowRef = window
 
   // Use the app icon as tray icon
@@ -87,6 +127,7 @@ export function createTray(window) {
  * @param {string} body
  */
 export function showTaskNotification(title, body) {
+  const { Notification } = electronApi()
   if (!Notification.isSupported()) return
 
   const notification = new Notification({

--- a/src/tray.test.js
+++ b/src/tray.test.js
@@ -1,0 +1,42 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { resolveTrayIconPath, shouldHideOnClose } from './tray.js'
+
+describe('resolveTrayIconPath', () => {
+  it('uses extraResources layout when packaged', () => {
+    assert.equal(
+      resolveTrayIconPath({
+        isPackaged: true,
+        resourcesPath: '/App.app/Contents/Resources',
+        projectRoot: '/repo',
+      }),
+      '/App.app/Contents/Resources/assets/icon.png',
+    )
+  })
+
+  it('uses the repo assets folder when unpackaged', () => {
+    assert.equal(
+      resolveTrayIconPath({
+        isPackaged: false,
+        resourcesPath: '/unused',
+        projectRoot: '/repo',
+      }),
+      '/repo/assets/icon.png',
+    )
+  })
+})
+
+describe('shouldHideOnClose', () => {
+  it('hides on macOS when the user is not quitting', () => {
+    assert.equal(shouldHideOnClose({ isQuitting: false, platform: 'darwin' }), true)
+  })
+
+  it('does not hide when quitting so the kernel can stop', () => {
+    assert.equal(shouldHideOnClose({ isQuitting: true, platform: 'darwin' }), false)
+  })
+
+  it('does not hide on Windows or Linux', () => {
+    assert.equal(shouldHideOnClose({ isQuitting: false, platform: 'win32' }), false)
+    assert.equal(shouldHideOnClose({ isQuitting: false, platform: 'linux' }), false)
+  })
+})


### PR DESCRIPTION
## Summary

After merging #22, extract `resolveTrayIconPath` and `shouldHideOnClose` so unit tests drive the shipped hide-vs-quit and packaged-icon path. Version bump to **0.1.4**.

- Close-to-tray on macOS still keeps the kernel running.
- Quit (tray / Dock / Cmd+Q) still stops the kernel process tree.
- No preload. `task-complete` IPC remains unused.
- Does **not** overwrite `v0.1.2`.

## Test plan

- [x] `npm test` — 75 pass (5 new tray tests)
- [x] Packaged kernel HTTP probe twice — both 200 + HTML
- [x] `electron-builder --mac` produced `DeepSeek-Harness-Desktop-0.1.4-arm64.dmg` / `.zip` (unsigned; codesign failed in this SSH session)